### PR TITLE
Add playerhead icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ buildNumber.properties
 
 # Common working directory
 run/
+
+# Minecraft server for testing
+testserver/

--- a/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
+++ b/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
@@ -16,6 +16,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,8 @@ import java.net.URL;
 import java.util.Optional;
 
 public final class main extends JavaPlugin implements Listener {
+
+	boolean isDebugBuild = true; // Enables some extra debugging code when true. Disable in production builds
 
 	final String markerSetId = "offplrs";
 	final String markerSetName = "Offline Players";
@@ -104,13 +107,19 @@ public final class main extends JavaPlugin implements Listener {
 	}
 
 	String createMarkerImage (BlueMapAPI blueMapAPI, Player player) {
-		String pathToModifiedPlayerhead = "offlineplayerheads/" + player.getUniqueId() + ".png";
+		String pathToModifiedPlayerhead = "offlineplayerheads/" + player.getUniqueId().toString();
 		BufferedImage image = null;
+
+		// Some debugging
+		if (isDebugBuild) {
+			getLogger().info("UUID of player " + player.getName() + " is " + player.getUniqueId().toString());
+			getLogger().info("Wanted path to marker image: " + pathToModifiedPlayerhead);
+		}
 
 		// Set the url as the crafatar endpoint
 		URL imageUrl = null;
 		try {
-			imageUrl = new URL("https://crafatar.com/avatars/" + player.getUniqueId() +".png?size=32&overlay=true");
+			imageUrl = new URL("https://crafatar.com/avatars/" + player.getUniqueId().toString() +".png?size=32&overlay=true");
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 		}
@@ -124,6 +133,8 @@ public final class main extends JavaPlugin implements Listener {
 			e.printStackTrace();
 		}
 
+		image = convertToGrayScale(image);
+
 		// Make the image file from the BufferedImage
 		try {
 			pathToModifiedPlayerhead = blueMapAPI.createImage(image, pathToModifiedPlayerhead);
@@ -131,9 +142,26 @@ public final class main extends JavaPlugin implements Listener {
 			e.printStackTrace();
 		}
 
+		// Debugging
+		if (isDebugBuild) {
+			getLogger().info("Actual path to marker image: " + pathToModifiedPlayerhead);
+		}
+
 		// Return the path to the image file
 		return pathToModifiedPlayerhead;
 
+	}
+
+	// Adapted from https://stackoverflow.com/questions/3106269/how-to-use-type-byte-gray-to-efficiently-create-a-grayscale-bufferedimage-using/12860219#12860219
+	BufferedImage convertToGrayScale(BufferedImage image) {
+		BufferedImage result = new BufferedImage(
+				image.getWidth(),
+				image.getHeight(),
+				BufferedImage.TYPE_BYTE_GRAY);
+		Graphics g = result.getGraphics();
+		g.drawImage(image, 0, 0, null);
+		g.dispose();
+		return result;
 	}
 
 	@Override

--- a/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
+++ b/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
@@ -104,16 +104,18 @@ public final class main extends JavaPlugin implements Listener {
 	}
 
 	String createMarkerImage (BlueMapAPI blueMapAPI, Player player) {
-		String pathToModifiedHeadFile = "assets/offlineplayerskins/" + player.getUniqueId() + ".png";
+		String pathToModifiedPlayerhead = "offlineplayerheads/" + player.getUniqueId() + ".png";
 		BufferedImage image = null;
 
+		// Set the url as the crafatar endpoint
 		URL imageUrl = null;
 		try {
-			imageUrl = new URL("https://crafatar.com/avatars/" + player.getUniqueId() +".png?size=32");
+			imageUrl = new URL("https://crafatar.com/avatars/" + player.getUniqueId() +".png?size=32&overlay=true");
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 		}
 
+		// Read the image from the url to a BufferedImage
 		try {
 			InputStream in = imageUrl.openStream();
 			image = ImageIO.read(in);
@@ -122,13 +124,15 @@ public final class main extends JavaPlugin implements Listener {
 			e.printStackTrace();
 		}
 
+		// Make the image file from the BufferedImage
 		try {
-			blueMapAPI.createImage(image, pathToModifiedHeadFile);
+			pathToModifiedPlayerhead = blueMapAPI.createImage(image, pathToModifiedPlayerhead);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 
-		return pathToModifiedHeadFile;
+		// Return the path to the image file
+		return pathToModifiedPlayerhead;
 
 	}
 

--- a/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
+++ b/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
@@ -1,5 +1,6 @@
 package net.mctechnic.bluemapofflineplayermarkers;
 
+import com.google.common.net.UrlEscapers;
 import de.bluecolored.bluemap.api.BlueMapAPI;
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.BlueMapWorld;
@@ -14,7 +15,13 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Optional;
 
 public final class main extends JavaPlugin implements Listener {
@@ -61,7 +68,7 @@ public final class main extends JavaPlugin implements Listener {
 				POIMarker marker = markerSet.createPOIMarker(player.getUniqueId().toString(), map,
 						player.getLocation().getX(), player.getLocation().getY(), player.getLocation().getZ()); //make the marker
 				marker.setLabel(player.getName());
-				marker.setIcon("assets/playerheads/" + player.getUniqueId() + ".png", 4, 4); //images
+				marker.setIcon(createMarkerImage(blueMapAPI, player), 16, 16);
 			}
 		}
 
@@ -94,6 +101,35 @@ public final class main extends JavaPlugin implements Listener {
 				markerSet.removeMarker(player.getUniqueId().toString()));
 
 		getLogger().info("Marker for " + player.getName() + " removed");
+	}
+
+	String createMarkerImage (BlueMapAPI blueMapAPI, Player player) {
+		String pathToModifiedHeadFile = "assets/offlineplayerskins/" + player.getUniqueId() + ".png";
+		BufferedImage image = null;
+
+		URL imageUrl = null;
+		try {
+			imageUrl = new URL("https://crafatar.com/avatars/" + player.getUniqueId() +".png?size=32");
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+
+		try {
+			InputStream in = imageUrl.openStream();
+			image = ImageIO.read(in);
+			in.close();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		try {
+			blueMapAPI.createImage(image, pathToModifiedHeadFile);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		return pathToModifiedHeadFile;
+
 	}
 
 	@Override

--- a/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
+++ b/src/main/java/net/mctechnic/bluemapofflineplayermarkers/main.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 public final class main extends JavaPlugin implements Listener {
 
-	boolean isDebugBuild = true; // Enables some extra debugging code when true. Disable in production builds
+	boolean isDebugBuild = false; // Enables some extra debugging code when true. Disable in production builds
 
 	final String markerSetId = "offplrs";
 	final String markerSetName = "Offline Players";


### PR DESCRIPTION
Makes the marker icons greyscale playerheads.

Closes #3.

I'm aware of the bug in the file names, however that is a BluemapAPI issue, fixed by a commit yesterday.