### PR TITLE
Implement offline player marker loading from playerdata files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,16 @@
     </properties>
     <url>https://github.com/TechnicJelle/</url>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <build>
         <plugins>
             <plugin>
@@ -32,7 +42,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.1-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -44,6 +54,14 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.flowpowered.</pattern>
+                            <shadedPattern>net.mctechnic.shadow.com.flowpowered.</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
             </plugin>
         </plugins>
         <resources>
@@ -81,6 +99,11 @@
             <artifactId>BlueMapAPI</artifactId>
             <version>v1.6.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.flowpowered</groupId>
+            <artifactId>flow-nbt</artifactId>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,14 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>com.flowpowered:flow-nbt</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.MF</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>

--- a/src/main/java/net/mctechnic/bluemapofflineplayermarkers/commands/OfflineMarkers.java
+++ b/src/main/java/net/mctechnic/bluemapofflineplayermarkers/commands/OfflineMarkers.java
@@ -1,0 +1,56 @@
+package net.mctechnic.bluemapofflineplayermarkers.commands;
+
+import net.mctechnic.bluemapofflineplayermarkers.main;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OfflineMarkers implements CommandExecutor, TabCompleter {
+
+    private static final String MARKERS_RESET = "All markers have been deleted";
+    private static final String MARKERS_LOADED = "Offline player markers have been loaded and created";
+
+    private main plugin;
+
+    public OfflineMarkers(main plugin){
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if(args.length != 1) return false;
+        if(args[0].equalsIgnoreCase("load")){
+            plugin.resetMarkers();
+            sender.sendMessage(ChatColor.GREEN + MARKERS_RESET);
+            plugin.loadMarkers();
+            sender.sendMessage(ChatColor.GREEN + MARKERS_LOADED);
+            return true;
+        }else if(args[0].equalsIgnoreCase("reset")){
+            plugin.resetMarkers();
+            sender.sendMessage(ChatColor.GREEN + MARKERS_RESET);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        List<String> completions = new ArrayList<>();
+        if(args.length == 1){
+            completions.add("load");
+            completions.add("reset");
+        }
+        if(args.length >= 1 && args[args.length -1].length() > 0){
+            String arg = args[args.length -1];
+            completions.removeIf(suggestion -> !suggestion.startsWith(arg));
+        }
+        return completions;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,3 +7,22 @@ depend:
 author: TechnicJelle
 description: Adds markers where players have logged off to BlueMap
 website: https://github.com/TechnicJelle/BlueMapOfflinePlayerMarkers
+commands:
+  offlinemarkers:
+    usage: /offlinemarkers [load|reset]
+    description: Loads offline player markers from playerdata files or clears the markerset
+    permission: bluemapofflineplayermarkers.commands.offlinemarkers
+permissions:
+  bluemapofflineplayermarkers.*:
+    children:
+      bluemapofflineplayermarkers.commands.*: true
+    default: op
+    description: All permissions for the BlueMapOfflinePlayerMarkers plugin
+  bluemapofflineplayermarkers.commands.*:
+    children:
+      bluemapofflineplayermarkers.commands.offlinemarkers: true
+    default: op
+    description: Permission for all commands
+  bluemapofflineplayermarkers.commands.offlinemarkers:
+    default: op
+    description: Permission for the /offlinemarkers command


### PR DESCRIPTION
Added features:
 - /offlinemarkers load
   - Loads player positions of all offline players from their playerdata nbt file and creates their markers
 - /offlinemarkers reset
   - Clears the markerset (I had to create the feature for the load command anyways, so I thought I'd just make it accessible from a command aswell)
  
Changes:
 - Shaded flow-nbt to net.mctechnic.shadow.com.flowpowered.nbt
 - Made addMarker require an OfflinePlayer and a Location instead of a Player (Since I didn't have access to Player objects when loading from playerdata files)
 - Added necessary config options to the plugin.yml for the command and its permissions
 - Updated the maven shade plugin to a snapshot that supports java 16
  
Probably needs some more testing on servers with more offline players, as I could only test it with a single one.